### PR TITLE
Fix Ubuntu-based image

### DIFF
--- a/work/Dockerfile.ubuntu
+++ b/work/Dockerfile.ubuntu
@@ -7,7 +7,19 @@ ENV TZ=America/New_York
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN mkdir -p epri 
 RUN apt-get -y update && \
-    apt-get install -y subversion git make cmake g++ fpc
+    apt-get install -y subversion git make g++ fpc wget libssl-dev
+# Install cmake=3.19.7 from source bc ubuntu package repo does not have version>=3.18
+# Install requires wget and libssl-dev
+RUN version=3.19 && \
+    build=7 && \
+    mkdir ~/temp && \
+    cd ~/temp && \
+    wget https://cmake.org/files/v$version/cmake-$version.$build.tar.gz && \
+    tar -xzvf cmake-$version.$build.tar.gz && \
+    cd cmake-$version.$build/ && \
+    ./bootstrap && \
+    make -j$(nproc) && \
+    make install
 RUN git clone https://github.com/pnnl/linenoise-ng.git
 RUN svn checkout https://svn.code.sf.net/p/klusolve/code/ KLUSolve
 RUN svn checkout https://svn.code.sf.net/p/electricdss/code/trunk/Version7/Source epri/electric-dss

--- a/work/Dockerfile.ubuntu
+++ b/work/Dockerfile.ubuntu
@@ -24,6 +24,10 @@ RUN git clone https://github.com/pnnl/linenoise-ng.git
 RUN svn checkout https://svn.code.sf.net/p/klusolve/code/ KLUSolve
 RUN svn checkout https://svn.code.sf.net/p/electricdss/code/trunk/Version7/Source epri/electric-dss
 
+# Rm -vm6058 flag from linuxopts.cfg for ubuntu.
+# Ubuntu fpc verson (3.0.2) does not include 6058 message and throws an error
+RUN sed -i -e 's/\(6058,\|,6058\)//g' /tmp/epri/electric-dss/CMD/linuxopts.cfg 
+
 COPY remove_obsolete_agent_calls.diff .
 RUN cd epri/electric-dss && \
     svn patch --non-interactive /tmp/remove_obsolete_agent_calls.diff


### PR DESCRIPTION
### Summary

`Dockerfile.ubuntu` fails to build an image. This PR builds that image successfully and produces results using the `testall.sh` script (at least for the Ubuntu version and using Docker).

The updates address two issues that relate to newer commits of `KLUSolve` and `OpenDSS` and their application requirements.

1) As explained in PR #5, `KLUSolve` explicitly requires `CMake` >=3.18 which is newer than the `CMake` version in the standard Ubuntu 20.04 repo. The solution was to add code to the Dockerfile to download a newer version directly from the website and install that version directly.

2) After using the newer version of `CMake`, the build failed while compiling `OpenDSS`. The issue was due to a configuration option in `linuxopts.cfg` (-vm6058) which threw an error using the latest version of `fpc` for Ubuntu. The issue seems to be that the latest version of `fpc` on Ubuntu 20.04 is prior to that error being included in `fpc` and even the particular build does not ignore `-vm` options which are not present. ([Reference](https://lists.lazarus-ide.org/pipermail/lazarus/2018-June/235010.html)).

The solution to issue 2 was to add a line to the docker image to delete "6050" argument from the `-vm` option from the `cfg` file if present in the configuration file.

### Result

Building an image from `Docker.ubuntu` is successful and passes the test in `testall.sh`.


@beroset, thank you so much for creating this repo. It was incredibly enlightening on how to compile OpenDSS (and programs in general) and use Dockerimages.

